### PR TITLE
Move CANDapterDevice initialization all to __init__

### DIFF
--- a/CANAdapterDevices.py
+++ b/CANAdapterDevices.py
@@ -1,5 +1,6 @@
 import serial
-
+import datetime
+import atexit
 
 class GenericCANAdapterDevice:
     def __init__(self):
@@ -23,7 +24,14 @@ class CANDapterDevice(GenericCANAdapterDevice):
                  debug=False):
 
         super().__init__()
+        # Set bitrate to 500Kbit and open CANDapter
+        # https://www.ewertenergy.com/products/candapter/downloads/candapter_manual.pdf
         self.canDapterDevice = serial.Serial(port, baudrate, timeout=timeout)
+        self.canDapter.sendSerialMessage('S6')
+        self.canDapter.sendSerialMessage('O')
+
+        # Always close the connection end, no need for the user to do it manually
+        atexit.register(self.closeConnection)
 
     def sendSerialMessage(self, message):
         self.canDapterDevice.write(message + '\r')

--- a/Main-Testbench.py
+++ b/Main-Testbench.py
@@ -2,10 +2,6 @@ from CANAdapterDevices import CANDapterDevice
 
 canDapter = CANDapterDevice()
 
-# Set bitrate to 500Kbit and open CANDapter
-canDapter.sendSerialMessage('S6')
-canDapter.sendSerialMessage('O')
-
 while True:
     data = canDapter.readCANMessage()
 


### PR DESCRIPTION
Some of it used to be in Main-Testbench.py which means that the user would have to have this code every time they needed to use the testbench. Move it into the __init__ because it will always need to be opened before it can be used.

Closes #3